### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM rustlang/rust:nightly as builder
+
+WORKDIR /app
+
+COPY ./ ./
+
+RUN cargo build --release
+
+FROM alpine:latest
+
+WORKDIR /root
+
+COPY --from=builder /app/target .
+
+CMD ["./target/release/bike_blockchain_backend"]


### PR DESCRIPTION
I checked to create a Kubernetes cluster on Google cloud platform, it's no longer possible with the free tier instance.
i also tried on Bluemix, but the cluster won't be created, I get an error, I will retry later.
Should I create Kubernetes files deployment file even we don't have cluster to use it?
Otherwise we could deploy the containers with a webapp on azure, we can deploy 10 per account, and I think we can do something to build the container and deploy it automatically with the last updates on the master branch.

Closes #40 