### PR TITLE
Made server handle base64 in a url safe way.

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -75,6 +75,7 @@ impl Backend {
         let dur = Duration::from_secs(16);
         while now.elapsed() < dur {
             self.peer_disc.poll(&self.network);
+            std::thread::sleep(std::time::Duration::from_millis(1));
         }
         self.initial_setup();
 


### PR DESCRIPTION
This may have implications on your [Simulation Client](https://github.com/SEP-G5/Simulation-Client) @Alfret . However, its a simple fix with:
```rust
encode(t.get_signature()),
```
into
```rust
encode_config(t.get_signature(), base64::URL_SAFE),
```